### PR TITLE
fix:logo-title在暗黑模式下显示颜色对比度低

### DIFF
--- a/src/layout/index.vue
+++ b/src/layout/index.vue
@@ -72,7 +72,7 @@ const appWrapper = computed(() => ({
 
   .logo-title {
     margin-left: .75rem;
-    color: black;
+    color: var(--el-menu-text-color);
   }
 }
 


### PR DESCRIPTION
1.修复一些显示细节
