### PR TITLE
优化表单设计器的组件初始化问题

### DIFF
--- a/src/views/form/designer/ComponentPanel/ComponentList.vue
+++ b/src/views/form/designer/ComponentPanel/ComponentList.vue
@@ -45,10 +45,12 @@ const {
 const componentRef = ref<HTMLDivElement>()
 
 const cloneComponent = (component: Component) => {
+  const newChildren = [];  
   proxy.$emit('update:fieldId', props.fieldId + 1)
   return {
     ...component,
-    field: `field_${props.fieldId}`
+    field: `field_${props.fieldId}`,
+    children: newChildren
   }
 }
 


### PR DESCRIPTION
消除子组件数据共享的问题，使得每个组件都独立初始化创建
修复效果如下：
![dac2a9cf57a8ac7ce8c64fa224c9580](https://github.com/tangllty/tang-vue/assets/49436413/2c15a9ce-587b-4395-beed-6fcee9972364)
